### PR TITLE
Issue 40 - JPA enhancement can cause Java EE deployment failure due to IllegalStateException

### DIFF
--- a/module/osgi-jpa/src/main/java/org/glassfish/osgijpa/JPAExtender.java
+++ b/module/osgi-jpa/src/main/java/org/glassfish/osgijpa/JPAExtender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/module/osgi-jpa/src/main/java/org/glassfish/osgijpa/JPAExtender.java
+++ b/module/osgi-jpa/src/main/java/org/glassfish/osgijpa/JPAExtender.java
@@ -275,8 +275,9 @@ public final class JPAExtender implements Extender, SynchronousBundleListener {
                 break;
             case ASYNCHRONOUS:
                 executorService.submit(runnable);
+                break;
             default:
-                throw new IllegalArgumentException("Unkown policy");
+                throw new IllegalArgumentException("Unknown policy");
         }
     }
 


### PR DESCRIPTION
This adds a missing break and fixes the text message for the exception.

Signed-off-by: Bob Mitchell <bjetal@gmail.com>